### PR TITLE
Added Cinder volume sample template.

### DIFF
--- a/heat2arm/translators/instances/base_instance.py
+++ b/heat2arm/translators/instances/base_instance.py
@@ -131,6 +131,7 @@ class BaseInstanceARMTranslator(BaseHeatARMTranslator):
                     "createOption": "FromImage"
                 }
             },
+            "networkProfile": {},
         }
 
         # add any attached volumes, if applicable:
@@ -150,10 +151,8 @@ class BaseInstanceARMTranslator(BaseHeatARMTranslator):
 
         network_interfaces = self._get_network_interfaces()
         if network_interfaces:
-            vm_properties.update({
-                "networkProfile": {
-                    "networkInterfaces": self._get_network_interfaces(),
-                }
+            vm_properties["networkProfile"].update({
+                "networkInterfaces": self._get_network_interfaces(),
             })
 
         vm_properties.update({

--- a/heat2arm/translators/instances/ec2_instance.py
+++ b/heat2arm/translators/instances/ec2_instance.py
@@ -96,7 +96,7 @@ class EC2InstanceARMTranslator(BaseInstanceARMTranslator):
                     resource.properties.data["InstanceId"] == self._name):
                 volume_name = resource.properties.data["VolumeId"].args
                 volumes.append({
-                    "name": self._name,
+                    "name": volume_name,
                     "diskSizeGB": "[parameters('size_%s')]" %
                                   volume_name,
                     "lun": lun,

--- a/heat2arm/translators/instances/nova_server.py
+++ b/heat2arm/translators/instances/nova_server.py
@@ -90,7 +90,7 @@ class NovaServerARMTranslator(BaseInstanceARMTranslator):
                     resource.properties.data["instance_uuid"] == self._name):
                 volume_name = resource.properties.data["volume_id"].args
                 volumes.append({
-                    "name": self._name,
+                    "name": volume_name,
                     "diskSizeGB": "[parameters('size_%s')]" %
                                   volume_name,
                     "lun": lun,

--- a/samples/vm_with_cinder.yaml
+++ b/samples/vm_with_cinder.yaml
@@ -1,0 +1,68 @@
+heat_template_version: 2013-05-23
+
+description: >
+  A HOT template that holds a VM instance with an attached
+  Cinder volume.  The VM does nothing, it is only created.
+
+parameters:
+  key_name:
+    type: string
+    description: Name of an existing key pair to use for the instance
+    constraints:
+      - custom_constraint: nova.keypair
+        description: Must name a public key (pair) known to Nova
+  flavor:
+    type: string
+    description: Flavor for the instance to be created
+    default: m1.small
+    constraints:
+      - custom_constraint: nova.flavor
+        description: Must be a flavor known to Nova
+  image:
+    type: string
+    description: >
+      Name or ID of the image to use for the instance.
+      You can get the default from
+      http://cloud.fedoraproject.org/fedora-20.x86_64.qcow2
+      There is also
+      http://cloud.fedoraproject.org/fedora-20.i386.qcow2
+      Any image should work since this template
+      does not ask the VM to do anything.
+    default: ubuntu.12.04.LTS.x86_64
+    constraints:
+      - custom_constraint: glance.image
+        description: Must identify an image known to Glance
+  network:
+    type: string
+    description: The network for the VM
+    default: private
+  vol_size:
+    type: number
+    description: The size of the Cinder volume
+    default: 1
+
+resources:
+  my_instance:
+    type: OS::Nova::Server
+    properties:
+      key_name: { get_param: key_name }
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      networks: [{network: {get_param: network} }]
+
+  my_vol:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: vol_size }
+
+  vol_att:
+    type: OS::Cinder::VolumeAttachment
+    properties:
+      instance_uuid: { get_resource: my_instance }
+      volume_id: { get_resource: my_vol }
+      mountpoint: /dev/vdb
+
+outputs:
+  instance_networks:
+    description: The IP addresses of the deployed instance
+    value: { get_attr: [my_instance, networks] }


### PR DESCRIPTION
Minor fixup for volume naming conventions and made networkProfile a default field regardless of it being empty.

Also, added Cinder volume sample template.
